### PR TITLE
CaT provisioning scripts inc PG

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
-# Scale BaT GPaaS
+# Scale CaT GPaaS
 ## Scripts and resources
+
+### Overview
+Provisions CaT (Contract for a Thing) API, UI and Postgres database
+
+### Usage
+See `cf-cat.sh` for usage notes.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# ccs-scale-cat-paas-infra
-Used to store infrastructure code for provisioning SCALE CaT components on UK Gov PaaS
+# Scale BaT GPaaS
+## Scripts and resources

--- a/cf-cat.sh
+++ b/cf-cat.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# CCS Scale BaT - GPaaS Cloud Foundry provisioning control script
+# CCS Scale CaT - GPaaS Cloud Foundry provisioning control script
 # Usage:
 # [SKIP_UPS=true] cf-cat.sh -o <ccs-scale-cat> -e <sbx1|sbx2|sbx3|sbx-spark|dev|int> <apply|destroy> <svcs|apps|all>
 #

--- a/cf-cat.sh
+++ b/cf-cat.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+#
+# CCS Scale BaT - GPaaS Cloud Foundry provisioning control script
+# Usage:
+# [SKIP_UPS=true] cf-cat.sh -o <ccs-scale-cat> -e <sbx1|sbx2|sbx3|sbx-spark|dev|int> <apply|destroy> <svcs|apps|all>
+#
+# SKIP_UPS (Skip User-provided services) can be set to true on subsequent backing service updates to avoid having to
+# re-enter all the values for each UPS
+#
+# e.g.
+# cf-cat.sh -o ccs-scale-cat -e sbx3 apply all
+# cf-cat.sh -o ccs-scale-cat -e sbx3 destroy apps
+# SKIPUPS=true cf-cat.sh -o ccs-scale-cat -e sbx3 apply svcs
+#
+
+set -meo pipefail
+
+usage() { echo "Usage: $0 [-o <ccs-scale-cat>] [-e <sbx1|sbx2|dev|int>] <apply|destroy> <svcs|apps|all>" 1>&2; exit 1; }
+
+get_environment_property () {
+  cat ${ENV_PROPS} | grep -w "$1" | cut -d'=' -f2
+}
+
+expand_var () {
+  echo $(eval echo "$1")
+}
+
+while getopts ":o:e:" o; do
+    case "${o}" in
+        o)
+            ORG=${OPTARG:='ccs-scale-cat'}
+            ;;
+        e)
+            export ENV=${OPTARG}
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+shift $((OPTIND-1))
+
+# Check null/empty options and args
+if [ -z "${ORG}" ] || [ -z "${ENV}" ] || [ -z "$1" ] || [ -z "$2" ]; then
+    usage
+fi
+
+ACTION=$1
+SCOPE=$2
+ENV_PROPS="./config/${ENV}.properties"
+
+if [[ ! -f $ENV_PROPS ]]; then
+  echo "Environment (space) config file [$ENV_PROPS] not found"
+  exit 1;
+fi
+
+if [[ $ACTION = "apply" ]]; then
+  . ./scripts/apply.sh
+elif [[ $ACTION = "destroy" ]]; then
+  . ./scripts/destroy.sh
+else
+  echo "Unrecognised action [$ACTION]. Only 'apply or 'destroy' are valid."
+  usage
+fi

--- a/config/dev.properties
+++ b/config/dev.properties
@@ -1,0 +1,8 @@
+# Sandbox environment
+SPACE=development
+
+# Compute - override in [env].properties
+INSTANCES_API=2
+
+# Service plans and names
+SERVICE_PLAN_PG=small-ha-11

--- a/config/global.properties
+++ b/config/global.properties
@@ -1,0 +1,25 @@
+# General properties
+#AWS_REGION=eu-west-2
+
+# Docker images from ECR:
+#DOCKER_IMAGE_SPREE=464702836434.dkr.ecr.eu-west-2.amazonaws.com/scale-bat-spree:latest
+
+# App names
+APP_NAME_API='$ENV-ccs-scale-cat-service'
+APP_NAME_UI='$ENV-ccs-scale-cat-ui'
+
+# Compute - override in [env].properties
+DISK_API=3G
+DISK_UI=3G
+MEMORY_API=4G # JDK buildpack requires 3GB plus - TODO: Revisit & Investigate
+MEMORY_UI=1G
+INSTANCES_API=1
+INSTANCES_UI=1
+
+# Service names and plans
+SERVICE_NAME_PG='$ENV-ccs-scale-cat-db'
+SERVICE_PLAN_PG=tiny-unencrypted-11
+
+# User-Provided Service names
+UPS_NAME='$ENV-ccs-scale-cat-ups-service'
+

--- a/config/int.properties
+++ b/config/int.properties
@@ -1,0 +1,8 @@
+# Sandbox environment
+SPACE=INT
+
+# Compute - override in [env].properties
+INSTANCES_API=2
+
+# Service plans and names
+SERVICE_PLAN_PG=small-ha-11

--- a/config/sbx1.properties
+++ b/config/sbx1.properties
@@ -1,0 +1,2 @@
+# Sandbox environment (Ade Milne)
+SPACE=sandbox

--- a/config/sbx2.properties
+++ b/config/sbx2.properties
@@ -1,0 +1,2 @@
+# Sandbox environment (Tom Bunting)
+SPACE=sandbox-2

--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# Applies (creates / updates) the CF infra
+#
+
+echo "ORG=${ORG}"
+echo "ENV=${ENV}"
+echo "ACTION=${ACTION}"
+echo "SCOPE=${SCOPE}"
+
+# Load global defaults and environment specific config
+. ./config/global.properties
+. ./config/$ENV.properties
+
+cf target -o $ORG -s $SPACE
+
+# Create / update backing services
+if [[ $SCOPE =~ svcs|all ]]; then
+  . ./scripts/create-services.sh
+fi
+
+# Create / update applications
+if [[ $SCOPE =~ app|all ]]; then
+  export CF_DOCKER_PASSWORD=$AWS_ECR_REPO_SECRET_ACCESS_KEY
+
+  # CaT API & UI
+  APP_NAME=$(expand_var $APP_NAME_API)
+  . ./scripts/create-cat-api.sh
+  # . ./scripts/create-cat-ui.sh
+fi

--- a/scripts/create-cat-api.sh
+++ b/scripts/create-cat-api.sh
@@ -9,7 +9,6 @@
 
   # Map an internal route to CaT API backend for UI
   # cf map-route $APP_NAME apps.internal --hostname $APP_NAME
-fi
 
 #######################
 # Bind to Services

--- a/scripts/create-cat-api.sh
+++ b/scripts/create-cat-api.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+#######################
+# CaT API - TODO: Rely on deployment via travis only / in certain envs?
+#######################
+  # cf push -k $DISK_API -m $MEMORY_API -i $INSTANCES_API $APP_NAME \
+  #   --docker-image $DOCKER_IMAGE_SPREE --docker-username $AWS_ECR_REPO_ACCESS_KEY_ID \
+  #   -c "bundle exec sidekiq" --no-start --no-route -u process
+
+  # Map an internal route to CaT API backend for UI
+  # cf map-route $APP_NAME apps.internal --hostname $APP_NAME
+fi
+
+#######################
+# Bind to Services
+#######################
+cf bind-service $APP_NAME $(expand_var $SERVICE_NAME_PG)
+
+# UPS
+cf bind-service $APP_NAME $(expand_var $UPS_NAME)
+
+##################################
+# Set Environment Variables in App
+##################################
+
+# TODO: Improve the sed command to remove need to prefix with additional '{' char
+VCAP_SERVICES="{$(cf env $APP_NAME | sed -n '/^VCAP_SERVICES:/,/^$/{//!p;}')"
+
+echo "${VCAP_SERVICES}"
+echo "${ENV}"
+echo "${APP_NAME}"
+ENV_UPS_NAME=$(expand_var $UPS_NAME)
+
+# CaT API
+cf set-env $APP_NAME AGREEMENTS_SERVICE_API_KEY $(echo $VCAP_SERVICES | jq -r '."user-provided"[] | select(.name == env.ENV_UPS_NAME).credentials."agreements-svc-api-key"')
+cf set-env $APP_NAME AGREEMENTS_SERVICE_URL $(echo $VCAP_SERVICES | jq -r '."user-provided"[] | select(.name == env.ENV_UPS_NAME).credentials."agreements-svc-url"')
+cf set-env $APP_NAME "spring.security.oauth2.client.registration.jaggaer.client-id" $(echo $VCAP_SERVICES | jq -r '."user-provided"[] | select(.name == env.ENV_UPS_NAME).credentials."jaggaer-client-id"')
+cf set-env $APP_NAME "spring.security.oauth2.client.registration.jaggaer.client-secret" $(echo $VCAP_SERVICES | jq -r '."user-provided"[] | select(.name == env.ENV_UPS_NAME).credentials."jaggaer-client-secret"')
+cf set-env $APP_NAME "spring.security.oauth2.resourceserver.jwt.jwk-set-uri" $(echo $VCAP_SERVICES | jq -r '."user-provided"[] | select(.name == env.ENV_UPS_NAME).credentials."auth-server-jwk-set-uri"')
+
+# Static / miscellaneous
+#cf set-env $APP_NAME APP_DOMAIN "$APP_NAME.london.cloudapps.digital"
+
+#######################
+# Restage and start
+#######################
+cf restage $APP_NAME

--- a/scripts/create-services.sh
+++ b/scripts/create-services.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+##################
+# Postgres Service
+##################
+cf create-service postgres $SERVICE_PLAN_PG $(expand_var ${SERVICE_NAME_PG})
+
+#############
+# User-Provided Services
+# Encapsulates external service details including credentials. Prompts for user input.
+#############
+create_update_ups () {
+  UPS_NAME=$1
+  UPS_LABEL=$2
+  UPS_PROPS=$3
+
+  # If the service already exists, update it otherwise create it
+  if cf service $UPS_NAME &> /dev/null; then
+    # TODO: Create github issue - input prompt does not work
+    # https://github.com/cloudfoundry/cli/issues
+    echo "Update $UPS_LABEL service details as prompted:"
+    # cf uups $UPS_NAME -p "$UPS_PROPS"
+  else
+    echo "Enter $UPS_LABEL service details as prompted:"
+    cf cups $UPS_NAME -p "$UPS_PROPS"
+  fi
+}
+
+# Set env/shell variable SKIP_UPS=true to avoid re-running these commands
+if [[ "$SKIP_UPS" != true ]]; then
+  ENV_UPS_NAME=$(expand_var $UPS_NAME)
+  ENV_UPS_LABEL="${ENV} CaT UPS"
+  UPS_PROPS="jaggaer-client-id, jaggaer-client-secret, auth-server-jwk-set-uri, agreements-svc-api-key, agreements-svc-url"
+  create_update_ups "$ENV_UPS_NAME" "$ENV_UPS_LABEL" "$UPS_PROPS"
+fi

--- a/scripts/destroy-apps.sh
+++ b/scripts/destroy-apps.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+###############
+# Delete network policies
+###############
+cf remove-network-policy $(expand_var $APP_NAME_UI) $(expand_var $APP_NAME_API) -s $SPACE -o $ORG --protocol tcp --port 8080 || true
+
+#######################
+# CaT API Service
+#######################
+cf delete -f $(expand_var $APP_NAME_UI)
+cf delete -f $(expand_var $APP_NAME_API)

--- a/scripts/destroy-services.sh
+++ b/scripts/destroy-services.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+##################
+# Postgres Service
+##################
+cf delete-service -f $(expand_var ${SERVICE_NAME_PG})
+
+#############
+# User-Provided Services
+#############
+cf delete-service -f $(expand_var $UPS_NAME)

--- a/scripts/destroy.sh
+++ b/scripts/destroy.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# Destroys the CF infra
+#
+
+echo "ORG=${ORG}"
+echo "ENV=${ENV}"
+echo "ACTION=${ACTION}"
+echo "SCOPE=${SCOPE}"
+
+# Load global defaults and environment specific config
+. ./config/global.properties
+. ./config/$ENV.properties
+
+cf target -o $ORG -s $SPACE
+
+# Destroy applications
+if [[ $SCOPE =~ app|all ]]; then
+  . ./scripts/destroy-apps.sh
+fi
+
+# Destroy backing services
+if [[ $SCOPE =~ svcs|all ]]; then
+  . ./scripts/destroy-services.sh
+fi


### PR DESCRIPTION
Stripped down version of ccs-scale-bat-paas-infra.  Only usable for creating the services at the moment but most of what we need for updating the app with the necessary secrets should also be here... there will be some more changes but should be minimal.
Run against sandbox-2 space (sbx2 'environment' in the config) with:

    ./cf-cat.sh -o ccs-scale-cat -e sbx2 apply svcs

Entering the current values for Jaggaer client-id and secret, agreements service key and url and Auth service JWK set-uri when prompted (these will be added to the UPS which will then be queried to set the app env vars).
Can then provision the schema via the conduit plugin:

    cf conduit [env]-ccs-scale-cat-db -- psql

Once logged in to the DB you can copy/paste the contents of https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-scale-db-scripts/develop/tenders-api/ddl.sql and hit enter - seems to work.  Sure there's a more elegant way.... I tried a few variations on wget'ing the contents and passing them in but none worked so didn't seem worth pursuing further at this point.