### PR TITLE
Configurable (by space) allowed IPs for routing service

### DIFF
--- a/config/global.properties
+++ b/config/global.properties
@@ -3,18 +3,22 @@
 
 # Docker images from ECR:
 #DOCKER_IMAGE_SPREE=464702836434.dkr.ecr.eu-west-2.amazonaws.com/scale-bat-spree:latest
+REGION_DOMAIN=london.cloudapps.digital
 
 # App names
 APP_NAME_API='$ENV-ccs-scale-cat-service'
 APP_NAME_UI='$ENV-ccs-scale-cat-ui'
+APP_NAME_IP_ROUTER='$ENV-ccs-scale-cat-ip-router'
 
 # Compute - override in [env].properties
 DISK_API=3G
 DISK_UI=3G
 MEMORY_API=4G # JDK buildpack requires 3GB plus - TODO: Revisit & Investigate
 MEMORY_UI=1G
+MEMORY_IP_ROUTER=256M
 INSTANCES_API=1
 INSTANCES_UI=1
+INSTANCES_IP_ROUTER=1
 
 # Service names and plans
 SERVICE_NAME_PG='$ENV-ccs-scale-cat-db'
@@ -22,4 +26,9 @@ SERVICE_PLAN_PG=tiny-unencrypted-11
 
 # User-Provided Service names
 UPS_NAME='$ENV-ccs-scale-cat-ups-service'
+UPS_NAME_ROUTE_SERVICE='$ENV-ccs-scale-cat-ups-route-service'
 
+# Allowed external IP ranges
+NGINX_CIDRS_ALLOWED_EXTERNAL=`cat << EOF 
+allow 0.0.0.0/0;
+EOF`

--- a/config/global.properties
+++ b/config/global.properties
@@ -32,3 +32,6 @@ UPS_NAME_ROUTE_SERVICE='$ENV-ccs-scale-cat-ups-route-service'
 NGINX_CIDRS_ALLOWED_EXTERNAL=`cat << EOF 
 allow 0.0.0.0/0;
 EOF`
+
+# Service keys
+SERVICE_KEY_PG='$ENV-ccs-scale-cat-db-svc-key'

--- a/ip-router-app/manifest.yml
+++ b/ip-router-app/manifest.yml
@@ -1,0 +1,13 @@
+---
+applications:
+  - name: ((APP_NAME))
+    instances: ((INSTANCES))
+    memory: ((MEMORY))
+    buildpacks:
+      - nginx_buildpack
+
+    health-check-type: http
+    health-check-http-endpoint: /_route-service-health
+
+    env:
+      APP_NAME: ((APP_NAME))

--- a/ip-router-app/nginx.conf
+++ b/ip-router-app/nginx.conf
@@ -1,0 +1,107 @@
+worker_processes 4;
+daemon off;
+
+error_log /dev/stderr;
+
+events {
+  worker_connections 1024;
+}
+
+http {
+  charset utf-8;
+
+  log_format access_json '{"logType": "nginx-access", '
+                         ' "remoteHost": "$remote_addr", '
+                         ' "user": "$remote_user", '
+                         ' "time": "$time_local", '
+                         ' "request": "$request", '
+                         ' "status": $status, '
+                         ' "size": $body_bytes_sent, '
+                         ' "referer": "$http_referer", '
+                         ' "userAgent": "$http_user_agent", '
+                         ' "requestTime": $request_time, '
+                         ' "httpHost": "$http_host"}';
+
+  access_log /dev/stdout access_json;
+  default_type application/octet-stream;
+  sendfile on;
+  tcp_nopush on;
+  keepalive_timeout 30;
+  port_in_redirect off;
+  server_tokens off;
+
+  expires -1;
+
+  real_ip_header X-Forwarded-For;
+  set_real_ip_from 10.0.0.0/8;
+  set_real_ip_from 127.0.0.1/32;
+  set_real_ip_from 172.16.0.0/12;
+  set_real_ip_from 192.168.0.0/16;
+  real_ip_recursive on;
+
+  server {
+    listen {{ port }};
+    server_name localhost;
+
+    satisfy any;
+
+    error_page 403 = @forbidden;
+
+    location @forbidden {
+      allow all;
+      access_log off;
+
+      default_type text/plain;
+      return 403 'Forbidden by {{ env "APP_NAME" }}';
+    }
+
+    location @check {
+      default_type text/plain;
+      return 200 'OK';
+    }
+
+    location = /_route-service-health {
+      allow all;
+      access_log off;
+
+      stub_status on;
+      access_log off;
+    }
+
+    location = /_route-service-check {
+      allow 127.0.0.1/32;
+      {{env "ALLOWED_IPS"}}
+      deny all;
+
+      try_files $uri @check;
+    }
+
+    location / {
+      allow 127.0.0.1/32;
+      {{env "ALLOWED_IPS"}}
+      deny all;
+
+      resolver 169.254.0.2;
+
+      set $cf_forwarded_host '*';
+      set $cf_forwarded_uri '*';
+
+      if ($http_x_cf_forwarded_url ~* ^(https?\:\/\/)(.*?)\/(.*)$) {
+        set $cf_forwarded_host $2;
+        set $cf_forwarded_uri /$3;
+      }
+
+      proxy_http_version 1.1;
+      proxy_ssl_server_name on;
+      proxy_ssl_protocols TLSv1.2;
+      proxy_set_header Connection "";
+      proxy_set_header Host $cf_forwarded_host;
+      proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+
+      # Use XX-CF-APP-INSTANCE on the original request if you wish to target an instance
+      proxy_set_header X-CF-APP-INSTANCE $http_xx_cf_app_instance;
+
+      proxy_pass $http_x_forwarded_proto://$http_host$cf_forwarded_uri;
+    }
+  }
+}

--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -17,6 +17,7 @@ cf target -o $ORG -s $SPACE
 # Create / update backing services
 if [[ $SCOPE =~ svcs|all ]]; then
   . ./scripts/create-services.sh
+  . ./scripts/create-ip-router-service.sh
 fi
 
 # Create / update applications

--- a/scripts/create-ip-router-service.sh
+++ b/scripts/create-ip-router-service.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+#######################
+# CaT IP authentication app and router service
+# See: 
+# https://docs.cloud.service.gov.uk/deploying_services/route_services/#example-route-service-to-add-ip-address-authentication
+#######################
+
+ENV_APP_NAME_IP_ROUTER=$(expand_var $APP_NAME_IP_ROUTER)
+ENV_UPS_NAME_ROUTE_SERVICE=$(expand_var $UPS_NAME_ROUTE_SERVICE)
+
+# Push the IP Router app (nginx)
+cf push -f ./ip-router-app/manifest.yml -p ./ip-router-app --var APP_NAME=$ENV_APP_NAME_IP_ROUTER \
+    --var INSTANCES=$INSTANCES_IP_ROUTER --var MEMORY=$MEMORY_IP_ROUTER --no-start
+
+# Create or update the route service
+if cf service $ENV_UPS_NAME_ROUTE_SERVICE &> /dev/null; then
+    cf uups $ENV_UPS_NAME_ROUTE_SERVICE -r "https://${ENV_APP_NAME_IP_ROUTER}.${REGION_DOMAIN}"
+else
+    cf cups $ENV_UPS_NAME_ROUTE_SERVICE -r "https://${ENV_APP_NAME_IP_ROUTER}.${REGION_DOMAIN}"
+fi
+
+cf set-env $ENV_APP_NAME_IP_ROUTER ALLOWED_IPS "${NGINX_CIDRS_ALLOWED_EXTERNAL}"
+cf restage $ENV_APP_NAME_IP_ROUTER
+
+# Bind the route service to the app(s)
+# TODO: Replace HOSTNAME with that of the cat-buyer-ui once known and reinstate
+# cf bind-route-service $REGION_DOMAIN --hostname "test-ip-router" $ENV_UPS_NAME_ROUTE_SERVICE

--- a/scripts/create-services.sh
+++ b/scripts/create-services.sh
@@ -3,7 +3,15 @@
 ##################
 # Postgres Service
 ##################
-cf create-service postgres $SERVICE_PLAN_PG $(expand_var ${SERVICE_NAME_PG})
+ENV_SERVICE_NAME_PG=$(expand_var ${SERVICE_NAME_PG})
+cf create-service postgres $SERVICE_PLAN_PG $ENV_SERVICE_NAME_PG
+
+while cf service "${ENV_SERVICE_NAME_PG}" | grep -q "in progress"; do
+    sleep 20
+    echo "Waiting for ${ENV_SERVICE_NAME_PG} to finish provisioning..."
+done
+
+cf create-service-key $(expand_var ${SERVICE_NAME_PG}) $(expand_var ${SERVICE_KEY_PG})
 
 #############
 # User-Provided Services

--- a/scripts/destroy-services.sh
+++ b/scripts/destroy-services.sh
@@ -9,3 +9,11 @@ cf delete-service -f $(expand_var ${SERVICE_NAME_PG})
 # User-Provided Services
 #############
 cf delete-service -f $(expand_var $UPS_NAME)
+cf delete-service -f $(expand_var $UPS_NAME_ROUTE_SERVICE)
+
+#############
+# Router service app
+#############
+cf delete -f $(expand_var $APP_NAME_IP_ROUTER)
+
+

--- a/scripts/destroy-services.sh
+++ b/scripts/destroy-services.sh
@@ -9,6 +9,9 @@ cf delete-service -f $(expand_var ${SERVICE_NAME_PG})
 # User-Provided Services
 #############
 cf delete-service -f $(expand_var $UPS_NAME)
+
+# Uncomment / reinstate as required for each binding to the router service
+# cf unbind-service test-ip-router $(expand_var $UPS_NAME_ROUTE_SERVICE)
 cf delete-service -f $(expand_var $UPS_NAME_ROUTE_SERVICE)
 
 #############

--- a/scripts/destroy-services.sh
+++ b/scripts/destroy-services.sh
@@ -1,18 +1,32 @@
 #!/bin/bash
+set +e +o pipefail
+
+ENV_SERVICE_NAME_PG=$(expand_var ${SERVICE_NAME_PG})
+ENV_APP_NAME_API=$(expand_var ${APP_NAME_API})
+ENV_UPS_NAME=$(expand_var $UPS_NAME)
+ENV_UPS_NAME_ROUTE_SERVICE=$(expand_var $UPS_NAME_ROUTE_SERVICE)
 
 ##################
 # Postgres Service
 ##################
-cf delete-service -f $(expand_var ${SERVICE_NAME_PG})
+cf delete-service-key -f $ENV_SERVICE_NAME_PG $(expand_var ${SERVICE_KEY_PG})
+cf unbind-service $(expand_var ${APP_NAME_API}) $ENV_SERVICE_NAME_PG
+cf delete-service -f $ENV_SERVICE_NAME_PG
+
+while cf service "${ENV_SERVICE_NAME_PG}" | grep -q "delete in progress"; do
+    sleep 10
+    echo "Waiting for ${ENV_SERVICE_NAME_PG} to finish deleting..."
+done
 
 #############
 # User-Provided Services
 #############
-cf delete-service -f $(expand_var $UPS_NAME)
+cf unbind-service $ENV_APP_NAME_API $ENV_UPS_NAME
+cf delete-service -f $ENV_UPS_NAME
 
 # Uncomment / reinstate as required for each binding to the router service
-# cf unbind-service test-ip-router $(expand_var $UPS_NAME_ROUTE_SERVICE)
-cf delete-service -f $(expand_var $UPS_NAME_ROUTE_SERVICE)
+cf unbind-route-service -f $REGION_DOMAIN --hostname "test-ip-router" $ENV_UPS_NAME_ROUTE_SERVICE
+cf delete-service -f $ENV_UPS_NAME_ROUTE_SERVICE
 
 #############
 # Router service app


### PR DESCRIPTION
Decided given the debate earlier to set the default allowed IP range to "everything".  Seems to work - you can change it to multiline CCS range, or whatever and it blocks / allows accordingly.
I'll zip my little html app up and send to you so you can test - push that, then just uncomment [this line](https://github.com/Crown-Commercial-Service/ccs-scale-cat-paas-infra/compare/feature/SINF-434_bastion_host?expand=1#diff-b087384fc5b261427ef20ec138694ed1ac3499786e101029735f845c7cd31924R28) and run:

    ./cf-cat.sh -o ccs-scale-cat -e sbx1 apply svcs