### PR TITLE
Feature/scc 582 nodejs buyer UI

### DIFF
--- a/config/global.properties
+++ b/config/global.properties
@@ -36,3 +36,6 @@ EOF`
 
 # Service keys
 SERVICE_KEY_PG='$ENV-ccs-scale-cat-db-svc-key'
+
+# Tenders API base url
+TENDERS_API_BASE_URL='http://$ENV-ccs-scale-cat-service.apps.internal:8080'

--- a/config/global.properties
+++ b/config/global.properties
@@ -7,7 +7,7 @@ REGION_DOMAIN=london.cloudapps.digital
 
 # App names
 APP_NAME_API='$ENV-ccs-scale-cat-service'
-APP_NAME_UI='$ENV-ccs-scale-cat-ui'
+APP_NAME_UI='$ENV-ccs-scale-cat-buyer-ui'
 APP_NAME_IP_ROUTER='$ENV-ccs-scale-cat-ip-router'
 
 # Compute - override in [env].properties

--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -25,7 +25,8 @@ if [[ $SCOPE =~ app|all ]]; then
   export CF_DOCKER_PASSWORD=$AWS_ECR_REPO_SECRET_ACCESS_KEY
 
   # CaT API & UI
-  APP_NAME=$(expand_var $APP_NAME_API)
+  APP_NAME_API=$(expand_var $APP_NAME_API)
+  APP_NAME_UI=$(expand_var $APP_NAME_UI)
   . ./scripts/create-cat-api.sh
-  # . ./scripts/create-cat-ui.sh
+  . ./scripts/create-cat-ui.sh
 fi

--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -25,8 +25,9 @@ if [[ $SCOPE =~ app|all ]]; then
   export CF_DOCKER_PASSWORD=$AWS_ECR_REPO_SECRET_ACCESS_KEY
 
   # CaT API & UI
-  APP_NAME_API=$(expand_var $APP_NAME_API)
-  APP_NAME_UI=$(expand_var $APP_NAME_UI)
+  ENV_APP_NAME_API=$(expand_var $APP_NAME_API)
+  ENV_APP_NAME_UI=$(expand_var $APP_NAME_UI)
   . ./scripts/create-cat-api.sh
   . ./scripts/create-cat-buyer-ui.sh
+  . ./scripts/create-log-drain-ups.sh
 fi

--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -28,5 +28,5 @@ if [[ $SCOPE =~ app|all ]]; then
   APP_NAME_API=$(expand_var $APP_NAME_API)
   APP_NAME_UI=$(expand_var $APP_NAME_UI)
   . ./scripts/create-cat-api.sh
-  . ./scripts/create-cat-ui.sh
+  . ./scripts/create-cat-buyer-ui.sh
 fi

--- a/scripts/create-cat-api.sh
+++ b/scripts/create-cat-api.sh
@@ -46,7 +46,7 @@ cf set-env $APP_NAME_API "spring.security.oauth2.resourceserver.jwt.jwk-set-uri"
 LOGIT_HOSTNAME=$(echo $VCAP_SERVICES | jq -r '."user-provided"[] | select(.name == env.ENV_UPS_NAME).credentials."logit-hostname"')
 LOGIT_PORT=$(echo $VCAP_SERVICES | jq -r '."user-provided"[] | select(.name == env.ENV_UPS_NAME).credentials."logit-port"')
 
-if cf service $UPS_NAME &> /dev/null; then
+if cf service $UPS_NAME_LOG_DRAIN_SERVICE &> /dev/null; then
 	cf uups $(expand_var $UPS_NAME_LOG_DRAIN_SERVICE) -l syslog-tls://$LOGIT_HOSTNAME:$LOGIT_PORT
 else
 	cf cups $(expand_var $UPS_NAME_LOG_DRAIN_SERVICE) -l syslog-tls://$LOGIT_HOSTNAME:$LOGIT_PORT

--- a/scripts/create-cat-api.sh
+++ b/scripts/create-cat-api.sh
@@ -3,52 +3,58 @@
 #######################
 # CaT API - TODO: Rely on deployment via travis only / in certain envs?
 #######################
-  # cf push -k $DISK_API -m $MEMORY_API -i $INSTANCES_API $APP_NAME \
+  # cf push -k $DISK_API -m $MEMORY_API -i $INSTANCES_API $APP_NAME_API \
   #   --docker-image $DOCKER_IMAGE_SPREE --docker-username $AWS_ECR_REPO_ACCESS_KEY_ID \
   #   -c "bundle exec sidekiq" --no-start --no-route -u process
 
   # Map an internal route to CaT API backend for UI
-  # cf map-route $APP_NAME apps.internal --hostname $APP_NAME
+  # cf map-route $APP_NAME_API apps.internal --hostname $APP_NAME_API
 
 #######################
 # Bind to Services
 #######################
-cf bind-service $APP_NAME $(expand_var $SERVICE_NAME_PG)
+cf bind-service $APP_NAME_API $(expand_var $SERVICE_NAME_PG)
 
 # UPS
-cf bind-service $APP_NAME $(expand_var $UPS_NAME)
+cf bind-service $APP_NAME_API $(expand_var $UPS_NAME)
 
 ##################################
 # Set Environment Variables in App
 ##################################
 
 # TODO: Improve the sed command to remove need to prefix with additional '{' char
-VCAP_SERVICES="{$(cf env $APP_NAME | sed -n '/^VCAP_SERVICES:/,/^$/{//!p;}')"
+VCAP_SERVICES="{$(cf env $APP_NAME_API | sed -n '/^VCAP_SERVICES:/,/^$/{//!p;}')"
 
 echo "${VCAP_SERVICES}"
 echo "${ENV}"
-echo "${APP_NAME}"
+echo "${APP_NAME_API}"
 export ENV_UPS_NAME=$(expand_var $UPS_NAME)
 
 # CaT API
-cf set-env $APP_NAME AGREEMENTS_SERVICE_API_KEY $(echo $VCAP_SERVICES | jq -r '."user-provided"[] | select(.name == env.ENV_UPS_NAME).credentials."agreements-svc-api-key"')
-cf set-env $APP_NAME AGREEMENTS_SERVICE_URL $(echo $VCAP_SERVICES | jq -r '."user-provided"[] | select(.name == env.ENV_UPS_NAME).credentials."agreements-svc-url"')
-cf set-env $APP_NAME "spring.security.oauth2.client.registration.jaggaer.client-id" $(echo $VCAP_SERVICES | jq -r '."user-provided"[] | select(.name == env.ENV_UPS_NAME).credentials."jaggaer-client-id"')
-cf set-env $APP_NAME "spring.security.oauth2.client.registration.jaggaer.client-secret" $(echo $VCAP_SERVICES | jq -r '."user-provided"[] | select(.name == env.ENV_UPS_NAME).credentials."jaggaer-client-secret"')
-cf set-env $APP_NAME "spring.security.oauth2.resourceserver.jwt.jwk-set-uri" $(echo $VCAP_SERVICES | jq -r '."user-provided"[] | select(.name == env.ENV_UPS_NAME).credentials."auth-server-jwk-set-uri"')
+cf set-env $APP_NAME_API AGREEMENTS_SERVICE_API_KEY $(echo $VCAP_SERVICES | jq -r '."user-provided"[] | select(.name == env.ENV_UPS_NAME).credentials."agreements-svc-api-key"')
+cf set-env $APP_NAME_API AGREEMENTS_SERVICE_URL $(echo $VCAP_SERVICES | jq -r '."user-provided"[] | select(.name == env.ENV_UPS_NAME).credentials."agreements-svc-url"')
+cf set-env $APP_NAME_API "spring.security.oauth2.client.registration.jaggaer.client-id" $(echo $VCAP_SERVICES | jq -r '."user-provided"[] | select(.name == env.ENV_UPS_NAME).credentials."jaggaer-client-id"')
+cf set-env $APP_NAME_API "spring.security.oauth2.client.registration.jaggaer.client-secret" $(echo $VCAP_SERVICES | jq -r '."user-provided"[] | select(.name == env.ENV_UPS_NAME).credentials."jaggaer-client-secret"')
+cf set-env $APP_NAME_API "spring.security.oauth2.resourceserver.jwt.jwk-set-uri" $(echo $VCAP_SERVICES | jq -r '."user-provided"[] | select(.name == env.ENV_UPS_NAME).credentials."auth-server-jwk-set-uri"')
 
 # Static / miscellaneous
-#cf set-env $APP_NAME APP_DOMAIN "$APP_NAME.london.cloudapps.digital"
+#cf set-env $APP_NAME_API APP_DOMAIN "$APP_NAME_API.london.cloudapps.digital"
 
 #######################
 # Log drain to logit.io
 #######################
 LOGIT_HOSTNAME=$(echo $VCAP_SERVICES | jq -r '."user-provided"[] | select(.name == env.ENV_UPS_NAME).credentials."logit-hostname"')
 LOGIT_PORT=$(echo $VCAP_SERVICES | jq -r '."user-provided"[] | select(.name == env.ENV_UPS_NAME).credentials."logit-port"')
-cf cups $(expand_var $UPS_NAME_LOG_DRAIN_SERVICE) -l syslog-tls://$LOGIT_HOSTNAME:$LOGIT_PORT
-cf bind-service $APP_NAME $(expand_var $UPS_NAME_LOG_DRAIN_SERVICE)
+
+if cf service $UPS_NAME &> /dev/null; then
+	cf uups $(expand_var $UPS_NAME_LOG_DRAIN_SERVICE) -l syslog-tls://$LOGIT_HOSTNAME:$LOGIT_PORT
+else
+	cf cups $(expand_var $UPS_NAME_LOG_DRAIN_SERVICE) -l syslog-tls://$LOGIT_HOSTNAME:$LOGIT_PORT
+fi	
+	
+cf bind-service $APP_NAME_API $(expand_var $UPS_NAME_LOG_DRAIN_SERVICE)
 
 #######################
 # Restage and start
 #######################
-cf restage $APP_NAME
+cf restage $APP_NAME_API

--- a/scripts/create-cat-api.sh
+++ b/scripts/create-cat-api.sh
@@ -3,27 +3,27 @@
 #######################
 # CaT API - TODO: Rely on deployment via travis only / in certain envs?
 #######################
-  # cf push -k $DISK_API -m $MEMORY_API -i $INSTANCES_API $APP_NAME_API \
+  # cf push -k $DISK_API -m $MEMORY_API -i $INSTANCES_API $ENV_APP_NAME_API \
   #   --docker-image $DOCKER_IMAGE_SPREE --docker-username $AWS_ECR_REPO_ACCESS_KEY_ID \
   #   -c "bundle exec sidekiq" --no-start --no-route -u process
 
   # Map an internal route to CaT API backend for UI
-  # cf map-route $APP_NAME_API apps.internal --hostname $APP_NAME_API
+  # cf map-route $ENV_APP_NAME_API apps.internal --hostname $ENV_APP_NAME_API
 
 #######################
 # Bind to Services
 #######################
-cf bind-service $APP_NAME_API $(expand_var $SERVICE_NAME_PG)
+cf bind-service $ENV_APP_NAME_API $(expand_var $SERVICE_NAME_PG)
 
 # UPS
-cf bind-service $APP_NAME_API $(expand_var $UPS_NAME)
+cf bind-service $ENV_APP_NAME_API $(expand_var $UPS_NAME)
 
 ##################################
 # Set Environment Variables in App
 ##################################
 
 # TODO: Improve the sed command to remove need to prefix with additional '{' char
-VCAP_SERVICES="{$(cf env $APP_NAME_API | sed -n '/^VCAP_SERVICES:/,/^$/{//!p;}')"
+VCAP_SERVICES="{$(cf env $ENV_APP_NAME_API | sed -n '/^VCAP_SERVICES:/,/^$/{//!p;}')"
 
 echo "${VCAP_SERVICES}"
 echo "${ENV}"
@@ -31,30 +31,17 @@ echo "${APP_NAME_API}"
 export ENV_UPS_NAME=$(expand_var $UPS_NAME)
 
 # CaT API
-cf set-env $APP_NAME_API AGREEMENTS_SERVICE_API_KEY $(echo $VCAP_SERVICES | jq -r '."user-provided"[] | select(.name == env.ENV_UPS_NAME).credentials."agreements-svc-api-key"')
-cf set-env $APP_NAME_API AGREEMENTS_SERVICE_URL $(echo $VCAP_SERVICES | jq -r '."user-provided"[] | select(.name == env.ENV_UPS_NAME).credentials."agreements-svc-url"')
-cf set-env $APP_NAME_API "spring.security.oauth2.client.registration.jaggaer.client-id" $(echo $VCAP_SERVICES | jq -r '."user-provided"[] | select(.name == env.ENV_UPS_NAME).credentials."jaggaer-client-id"')
-cf set-env $APP_NAME_API "spring.security.oauth2.client.registration.jaggaer.client-secret" $(echo $VCAP_SERVICES | jq -r '."user-provided"[] | select(.name == env.ENV_UPS_NAME).credentials."jaggaer-client-secret"')
-cf set-env $APP_NAME_API "spring.security.oauth2.resourceserver.jwt.jwk-set-uri" $(echo $VCAP_SERVICES | jq -r '."user-provided"[] | select(.name == env.ENV_UPS_NAME).credentials."auth-server-jwk-set-uri"')
+cf set-env $ENV_APP_NAME_API AGREEMENTS_SERVICE_API_KEY $(echo $VCAP_SERVICES | jq -r '."user-provided"[] | select(.name == env.ENV_UPS_NAME).credentials."agreements-svc-api-key"')
+cf set-env $ENV_APP_NAME_API AGREEMENTS_SERVICE_URL $(echo $VCAP_SERVICES | jq -r '."user-provided"[] | select(.name == env.ENV_UPS_NAME).credentials."agreements-svc-url"')
+cf set-env $ENV_APP_NAME_API "spring.security.oauth2.client.registration.jaggaer.client-id" $(echo $VCAP_SERVICES | jq -r '."user-provided"[] | select(.name == env.ENV_UPS_NAME).credentials."jaggaer-client-id"')
+cf set-env $ENV_APP_NAME_API "spring.security.oauth2.client.registration.jaggaer.client-secret" $(echo $VCAP_SERVICES | jq -r '."user-provided"[] | select(.name == env.ENV_UPS_NAME).credentials."jaggaer-client-secret"')
+cf set-env $ENV_APP_NAME_API "spring.security.oauth2.resourceserver.jwt.jwk-set-uri" $(echo $VCAP_SERVICES | jq -r '."user-provided"[] | select(.name == env.ENV_UPS_NAME).credentials."auth-server-jwk-set-uri"')
 
 # Static / miscellaneous
-#cf set-env $APP_NAME_API APP_DOMAIN "$APP_NAME_API.london.cloudapps.digital"
+#cf set-env $ENV_APP_NAME_API APP_DOMAIN "$ENV_APP_NAME_API.london.cloudapps.digital"
 
-#######################
-# Log drain to logit.io
-#######################
-LOGIT_HOSTNAME=$(echo $VCAP_SERVICES | jq -r '."user-provided"[] | select(.name == env.ENV_UPS_NAME).credentials."logit-hostname"')
-LOGIT_PORT=$(echo $VCAP_SERVICES | jq -r '."user-provided"[] | select(.name == env.ENV_UPS_NAME).credentials."logit-port"')
-
-if cf service $UPS_NAME_LOG_DRAIN_SERVICE &> /dev/null; then
-	cf uups $(expand_var $UPS_NAME_LOG_DRAIN_SERVICE) -l syslog-tls://$LOGIT_HOSTNAME:$LOGIT_PORT
-else
-	cf cups $(expand_var $UPS_NAME_LOG_DRAIN_SERVICE) -l syslog-tls://$LOGIT_HOSTNAME:$LOGIT_PORT
-fi	
-	
-cf bind-service $APP_NAME_API $(expand_var $UPS_NAME_LOG_DRAIN_SERVICE)
 
 #######################
 # Restage and start
 #######################
-cf restage $APP_NAME_API
+cf restage $ENV_APP_NAME_API

--- a/scripts/create-cat-buyer-ui.sh
+++ b/scripts/create-cat-buyer-ui.sh
@@ -3,24 +3,20 @@
 ##################
 # CaT UI App
 ##################
-
 # Deployed via Travis build
 
 #######################
 # Bind to Services
 #######################
-
 cf bind-service $APP_NAME_UI $(expand_var $UPS_NAME)
 
 ##################
 # Create Network Policy
 # Allows public UI app to connect to private API service
 ##################
-
 cf add-network-policy $APP_NAME_UI $APP_NAME_API --protocol tcp --port 8080
 
 #######################
 # Log drain to logit.io
 #######################
-
 cf bind-service $APP_NAME_UI $(expand_var $UPS_NAME_LOG_DRAIN_SERVICE)

--- a/scripts/create-cat-buyer-ui.sh
+++ b/scripts/create-cat-buyer-ui.sh
@@ -8,15 +8,20 @@
 #######################
 # Bind to Services
 #######################
-cf bind-service $APP_NAME_UI $(expand_var $UPS_NAME)
+cf bind-service $ENV_APP_NAME_UI $(expand_var $UPS_NAME)
 
 ##################
 # Create Network Policy
 # Allows public UI app to connect to private API service
 ##################
-cf add-network-policy $APP_NAME_UI $APP_NAME_API --protocol tcp --port 8080
+cf add-network-policy $ENV_APP_NAME_UI $ENV_APP_NAME_API --protocol tcp --port 8080
 
 #######################
-# Log drain to logit.io
+# Set ENV variables
 #######################
-cf bind-service $APP_NAME_UI $(expand_var $UPS_NAME_LOG_DRAIN_SERVICE)
+cf set-env $ENV_APP_NAME_UI TENDERS_API_BASE_URL $(expand_var $TENDERS_API_BASE_URL)
+
+#######################
+# Restage and start
+#######################
+cf restage $ENV_APP_NAME_UI

--- a/scripts/create-cat-ui.sh
+++ b/scripts/create-cat-ui.sh
@@ -6,6 +6,11 @@
 
 # Deployed via Travis build
 
+#######################
+# Bind to Services
+#######################
+
+cf bind-service $APP_NAME_UI $(expand_var $UPS_NAME)
 
 ##################
 # Create Network Policy
@@ -13,7 +18,6 @@
 ##################
 
 cf add-network-policy $APP_NAME_UI $APP_NAME_API --protocol tcp --port 8080
-
 
 #######################
 # Log drain to logit.io

--- a/scripts/create-cat-ui.sh
+++ b/scripts/create-cat-ui.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+##################
+# CaT UI App
+##################
+
+# Deployed via Travis build
+
+
+##################
+# Create Network Policy
+# Allows public UI app to connect to private API service
+##################
+
+cf add-network-policy $APP_NAME_UI $APP_NAME_API --protocol tcp --port 8080
+
+
+#######################
+# Log drain to logit.io
+#######################
+
+cf bind-service $APP_NAME_UI $(expand_var $UPS_NAME_LOG_DRAIN_SERVICE)

--- a/scripts/create-log-drain-ups.sh
+++ b/scripts/create-log-drain-ups.sh
@@ -16,9 +16,9 @@ create_update_log_drain_ups () {
   LOGIT_PORT=$(echo $VCAP_SERVICES | jq -r '."user-provided"[] | select(.name == env.ENV_UPS_NAME).credentials."logit-port"')
 
   if cf service $UPS_NAME &> /dev/null; then
-	cf uups $UPS_NAME -l syslog-tls://$LOGIT_HOSTNAME:$LOGIT_PORT
+    cf uups $UPS_NAME -l syslog-tls://$LOGIT_HOSTNAME:$LOGIT_PORT
   else
-	cf cups $UPS_NAME -l syslog-tls://$LOGIT_HOSTNAME:$LOGIT_PORT
+    cf cups $UPS_NAME -l syslog-tls://$LOGIT_HOSTNAME:$LOGIT_PORT
   fi	
   
 }

--- a/scripts/create-log-drain-ups.sh
+++ b/scripts/create-log-drain-ups.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+#############
+# Log Drain User-Provided Service
+# Drains logs to logit.io
+#############
+create_update_log_drain_ups () {
+
+  APP_NAME=$1
+  UPS_NAME=$2
+
+  # TODO: Improve the sed command to remove need to prefix with additional '{' char
+  VCAP_SERVICES="{$(cf env $APP_NAME | sed -n '/^VCAP_SERVICES:/,/^$/{//!p;}')"
+
+  LOGIT_HOSTNAME=$(echo $VCAP_SERVICES | jq -r '."user-provided"[] | select(.name == env.ENV_UPS_NAME).credentials."logit-hostname"')
+  LOGIT_PORT=$(echo $VCAP_SERVICES | jq -r '."user-provided"[] | select(.name == env.ENV_UPS_NAME).credentials."logit-port"')
+
+  if cf service $UPS_NAME &> /dev/null; then
+	cf uups $UPS_NAME -l syslog-tls://$LOGIT_HOSTNAME:$LOGIT_PORT
+  else
+	cf cups $UPS_NAME -l syslog-tls://$LOGIT_HOSTNAME:$LOGIT_PORT
+  fi	
+  
+}
+
+
+ENV_LOG_DRAIN_UPS_NAME=$(expand_var $UPS_NAME_LOG_DRAIN_SERVICE)
+create_update_log_drain_ups "$ENV_APP_NAME_API" "$ENV_LOG_DRAIN_UPS_NAME"
+  
+cf bind-service $ENV_APP_NAME_API $(expand_var $UPS_NAME_LOG_DRAIN_SERVICE)
+cf bind-service $ENV_APP_NAME_UI $(expand_var $UPS_NAME_LOG_DRAIN_SERVICE)

--- a/scripts/create-services.sh
+++ b/scripts/create-services.sh
@@ -36,6 +36,6 @@ create_update_ups () {
 if [[ "$SKIP_UPS" != true ]]; then
   ENV_UPS_NAME=$(expand_var $UPS_NAME)
   ENV_UPS_LABEL="${ENV} CaT UPS"
-  UPS_PROPS="jaggaer-client-id, jaggaer-client-secret, auth-server-jwk-set-uri, agreements-svc-api-key, agreements-svc-url, logit-hostname, logit-port, conclave-url, conclave-client-id, conclave-client-secret, conclave-api-key, tenders-svc-url, tenders-svc-port"
+  UPS_PROPS="jaggaer-client-id, jaggaer-client-secret, auth-server-jwk-set-uri, agreements-svc-api-key, agreements-svc-url, logit-hostname, logit-port, conclave-url, conclave-client-id, conclave-client-secret, conclave-api-key"
   create_update_ups "$ENV_UPS_NAME" "$ENV_UPS_LABEL" "$UPS_PROPS"
 fi

--- a/scripts/create-services.sh
+++ b/scripts/create-services.sh
@@ -36,6 +36,6 @@ create_update_ups () {
 if [[ "$SKIP_UPS" != true ]]; then
   ENV_UPS_NAME=$(expand_var $UPS_NAME)
   ENV_UPS_LABEL="${ENV} CaT UPS"
-  UPS_PROPS="jaggaer-client-id, jaggaer-client-secret, auth-server-jwk-set-uri, agreements-svc-api-key, agreements-svc-url, logit-hostname, logit-port"
+  UPS_PROPS="jaggaer-client-id, jaggaer-client-secret, auth-server-jwk-set-uri, agreements-svc-api-key, agreements-svc-url, logit-hostname, logit-port, conclave-client-id, conclave-client-secret, conclave-x-api-key"
   create_update_ups "$ENV_UPS_NAME" "$ENV_UPS_LABEL" "$UPS_PROPS"
 fi

--- a/scripts/create-services.sh
+++ b/scripts/create-services.sh
@@ -36,6 +36,6 @@ create_update_ups () {
 if [[ "$SKIP_UPS" != true ]]; then
   ENV_UPS_NAME=$(expand_var $UPS_NAME)
   ENV_UPS_LABEL="${ENV} CaT UPS"
-  UPS_PROPS="jaggaer-client-id, jaggaer-client-secret, auth-server-jwk-set-uri, agreements-svc-api-key, agreements-svc-url, logit-hostname, logit-port, conclave-client-id, conclave-client-secret, conclave-x-api-key"
+  UPS_PROPS="jaggaer-client-id, jaggaer-client-secret, auth-server-jwk-set-uri, agreements-svc-api-key, agreements-svc-url, logit-hostname, logit-port, conclave-client-id, conclave-client-secret, conclave-api-key"
   create_update_ups "$ENV_UPS_NAME" "$ENV_UPS_LABEL" "$UPS_PROPS"
 fi

--- a/scripts/create-services.sh
+++ b/scripts/create-services.sh
@@ -36,6 +36,6 @@ create_update_ups () {
 if [[ "$SKIP_UPS" != true ]]; then
   ENV_UPS_NAME=$(expand_var $UPS_NAME)
   ENV_UPS_LABEL="${ENV} CaT UPS"
-  UPS_PROPS="jaggaer-client-id, jaggaer-client-secret, auth-server-jwk-set-uri, agreements-svc-api-key, agreements-svc-url, logit-hostname, logit-port, conclave-client-id, conclave-client-secret, conclave-api-key"
+  UPS_PROPS="jaggaer-client-id, jaggaer-client-secret, auth-server-jwk-set-uri, agreements-svc-api-key, agreements-svc-url, logit-hostname, logit-port, conclave-url, conclave-client-id, conclave-client-secret, conclave-api-key, tenders-svc-url, tenders-svc-port"
   create_update_ups "$ENV_UPS_NAME" "$ENV_UPS_LABEL" "$UPS_PROPS"
 fi


### PR DESCRIPTION
Updated PaaS infra to also deploy `cat-buyer-ui`. Note - updated name to include `buyer` as it reflects the name of the ui project (and I guess makes sense if we end up with admin/supplier UI's later). 

Added some extra notes in the comments.

Happy to change any/all if not quite right.

Note: there will be a corresponding PR for https://github.com/Crown-Commercial-Service/ccs-scale-cat-buyer-ui - to deploy the new NodeJS UI app example - just need to check our branch/merging strategy on that first.