### PR TITLE
Feature/scat 1834 redis

### DIFF
--- a/iac/environments/nft/main.tf
+++ b/iac/environments/nft/main.tf
@@ -12,4 +12,5 @@ module "deploy-all" {
   postgres_service_plan = "medium-ha-11"
   nginx_memory          = 2048
   nginx_instances       = 3
+  redis_service_plan    = "large-ha-6_x"
 }

--- a/iac/modules/configs/deploy-all/main.tf
+++ b/iac/modules/configs/deploy-all/main.tf
@@ -17,12 +17,12 @@ module "tenders-db" {
 }
 
 module "logit-ups" {
-  source           = "../../logit-ups"
-  organisation     = var.organisation
-  space            = var.space
-  environment      = var.environment
-  cf_username      = var.cf_username
-  cf_password      = var.cf_password
+  source       = "../../logit-ups"
+  organisation = var.organisation
+  space        = var.space
+  environment  = var.environment
+  cf_username  = var.cf_username
+  cf_password  = var.cf_password
 }
 
 module "ip-router" {
@@ -32,4 +32,14 @@ module "ip-router" {
   environment  = var.environment
   memory       = var.nginx_memory
   instances    = var.nginx_instances
+}
+
+module "redis" {
+  source       = "../../redis"
+  organisation = var.organisation
+  space        = var.space
+  environment  = var.environment
+  service_plan = var.redis_service_plan
+  create_timeout = var.redis_create_timeout
+  delete_timeout = var.redis_delete_timeout
 }

--- a/iac/modules/configs/deploy-all/main.tf
+++ b/iac/modules/configs/deploy-all/main.tf
@@ -35,11 +35,11 @@ module "ip-router" {
 }
 
 module "redis" {
-  source       = "../../redis"
-  organisation = var.organisation
-  space        = var.space
-  environment  = var.environment
-  service_plan = var.redis_service_plan
+  source         = "../../redis"
+  organisation   = var.organisation
+  space          = var.space
+  environment    = var.environment
+  service_plan   = var.redis_service_plan
   create_timeout = var.redis_create_timeout
   delete_timeout = var.redis_delete_timeout
 }

--- a/iac/modules/configs/deploy-all/variables.tf
+++ b/iac/modules/configs/deploy-all/variables.tf
@@ -37,3 +37,15 @@ variable "nginx_memory" {
 variable "nginx_instances" {
   default = 2
 }
+
+variable "redis_service_plan" {
+  default = "small-ha-6_x"
+}
+
+variable "redis_create_timeout" {
+  default = "30m"
+}
+
+variable "redis_delete_timeout" {
+  default = "30m"
+}

--- a/iac/modules/redis/main.tf
+++ b/iac/modules/redis/main.tf
@@ -1,0 +1,28 @@
+#########################################################
+# Cache: Redis
+#
+# Provision Redis cache for use by Buyer UI.
+#########################################################
+data "cloudfoundry_service" "redis" {
+  name = "redis"
+}
+
+data "cloudfoundry_org" "cat" {
+  name = var.organisation
+}
+
+data "cloudfoundry_space" "cloudfoundry_space" {
+  name = var.space
+  org  = data.cloudfoundry_org.cat.id
+}
+
+resource "cloudfoundry_service_instance" "redis-buyer-ui" {
+  name         = "${var.environment}-ccs-scale-cat-redis-buyer-ui"
+  space        = data.cloudfoundry_space.cloudfoundry_space.id
+  service_plan = data.cloudfoundry_service.redis.service_plans[var.service_plan]
+
+  timeouts {
+    create = var.create_timeout
+    delete = var.delete_timeout
+  }
+}

--- a/iac/modules/redis/provider.tf
+++ b/iac/modules/redis/provider.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    cloudfoundry = {
+      source  = "cloudfoundry-community/cloudfoundry"
+      version = "0.14.2"
+    }
+  }
+}

--- a/iac/modules/redis/variables.tf
+++ b/iac/modules/redis/variables.tf
@@ -1,0 +1,11 @@
+variable "organisation" {}
+
+variable "space" {}
+
+variable "environment" {}
+
+variable "service_plan" {}
+
+variable "create_timeout" {}
+
+variable "delete_timeout" {}


### PR DESCRIPTION
Added Redis cache for use by the Buyer UI (SCAT-1834).

Will follow up with a PR in `ccs-scale-cat-buyer-ui` repo that binds the UI to this redis cache.

Defaults to `small-ha-6_x` for all environments with override for NFT to use `large-ha-6_x` (pre prod and prod are not yet provisioned).