### PR TITLE
GMBP-263: Add documents S3 bucket

### DIFF
--- a/iac/compositions/cat-full/documents_bucket.tf
+++ b/iac/compositions/cat-full/documents_bucket.tf
@@ -1,0 +1,23 @@
+locals {
+  documents_bucket_name = format("%s-ccs-scale-cat-tenders-documents", var.resource_name_prefixes.hyphens_lower)
+}
+
+module "documents_bucket" {
+  source = "../../core/resource-groups/private-s3-bucket"
+
+  bucket_name  = local.documents_bucket_name
+  is_ephemeral = var.environment_is_ephemeral
+}
+
+data "aws_iam_policy_document" "documents_bucket_full_access" {
+  source_policy_documents = [
+    module.documents_bucket.delete_objects_policy_document_json,
+    module.documents_bucket.read_objects_policy_document_json,
+    module.documents_bucket.write_objects_policy_document_json,
+  ]
+}
+
+resource "aws_iam_policy" "documents_bucket_full_access" {
+  name   = "documents-bucket-full-access"
+  policy = data.aws_iam_policy_document.documents_bucket_full_access.json
+}

--- a/iac/compositions/cat-full/service_cat_api.tf
+++ b/iac/compositions/cat-full/service_cat_api.tf
@@ -2,7 +2,15 @@ locals {
   cat_api_spring_datasource_url = format("jdbc:postgresql://%s:%d/%s", module.db.db_connection_host, module.db.db_connection_port, module.db.db_connection_name)
 
   cat_api_vcap_object = {
-    #VCAP_SERVICES={"aws-s3-bucket": [{"aws_region": "..."}], "opensearch": [{"hostname": "abc", "username": "def", "password": "ghi", "port": "1234"}]}
+    aws-s3-bucket = [
+      {
+        aws_access_key_id     = "",
+        aws_secret_access_key = "",
+        aws_region            = var.aws_region,
+        bucket_name           = local.documents_bucket_name,
+        name                  = "aws-ccs-scale-cat-tenders-s3-documents", # Naming convention matters to the code
+      }
+    ],
     opensearch = [
       {
         "name"     = "aws-ccs-scale-cat-opensearch", # Naming convention matters to the code
@@ -128,6 +136,11 @@ module "cat_api_task" {
   family_name            = "cat_api"
   task_cpu               = var.task_container_configs.cat_api.total_cpu
   task_memory            = var.task_container_configs.cat_api.total_memory
+}
+
+resource "aws_iam_role_policy_attachment" "cat_api__documents_bucket_full_access" {
+  role       = module.cat_api_task.task_role_name
+  policy_arn = aws_iam_policy.documents_bucket_full_access.arn
 }
 
 resource "aws_ecs_service" "cat_api" {


### PR DESCRIPTION
This PR adds a private S3 bucket to replace an existing service instance in CloudFoundry that is read from, uploaded to and deleted from at several locations in the CAT API code.

It also exposes the details of this bucket into the `VCAP_SERVICES` environment variable, albeit without an AWS access key ID and secret access key as it is anticipated the application will leverage permissions afforded to the ECS task role to access the bucket.