### PR TITLE
GMTRP 200 allow 80 in public subnet

### DIFF
--- a/iac/compositions/cat-full/service_buyer_ui.tf
+++ b/iac/compositions/cat-full/service_buyer_ui.tf
@@ -284,6 +284,17 @@ resource "aws_security_group_rule" "buyer_ui_lb_http_in" {
   type              = "ingress"
 }
 
+resource "aws_network_acl_rule" "public__allow_http_everywhere_in" {
+  cidr_block     = "0.0.0.0/0"
+  egress         = false
+  from_port      = 80
+  network_acl_id = module.vpc.network_acl_ids.public
+  protocol       = "tcp"
+  rule_action    = "allow"
+  rule_number    = 10000
+  to_port        = 80
+}
+
 resource "aws_security_group_rule" "buyer_ui_lb_https_in" {
   description     = "Allow HTTPS from approved addresses into the Buyer UI LB"
   from_port       = 443


### PR DESCRIPTION
For the Buyer UI we provided an http listener on the Load Balancer; its job is to issue a blanket 301 redirect to any requests which it receives - This is to assist users who just type a hostname into their browser and hit "Go".

_However_ to facilitate this, the default NACL rules for the public subnet require port 80 to be permitted from everywhere - This additional rule was never implemented.

This PR addresses that.