### PR TITLE
Revert "Add missing Jaggaer SSM parameters"

### DIFF
--- a/iac/compositions/cat-full/manual_ssm_config.tf
+++ b/iac/compositions/cat-full/manual_ssm_config.tf
@@ -44,8 +44,6 @@ locals {
     "jaggaer-client-id",
     "jaggaer-project-template-id",
     "jaggaer-itt-template-id",
-    "jaggaer-enable-contract-plus",
-    "jaggaer-business-unit-name",
     "jaggaer-self-service-id",
     "jaggaer-token-url",
     "login-director-url",

--- a/iac/compositions/cat-full/service_cat_api.tf
+++ b/iac/compositions/cat-full/service_cat_api.tf
@@ -204,20 +204,12 @@ module "cat_api_task" {
           valueFrom = aws_ssm_parameter.manual_config["jaggaer-base-url"].arn
         },
         {
-          name      = "CONFIG_EXTERNAL_JAGGAER_BUSINESSUNITNAME",
-          valueFrom = aws_ssm_parameter.manual_config["jaggaer-business-unit-name"].arn
-        },
-        {
           name      = "CONFIG_EXTERNAL_JAGGAER_CREATEPROJECTTEMPLATEID",
           valueFrom = aws_ssm_parameter.manual_config["jaggaer-project-template-id"].arn
         },
         {
           name      = "CONFIG_EXTERNAL_JAGGAER_CREATERFXTEMPLATEID",
           valueFrom = aws_ssm_parameter.manual_config["jaggaer-itt-template-id"].arn
-        },
-        {
-          name      = "CONFIG_EXTERNAL_JAGGAER_ENABLECONTRACTPLUS",
-          valueFrom = aws_ssm_parameter.manual_config["jaggaer-enable-contract-plus"].arn
         },
         {
           name      = "CONFIG_EXTERNAL_JAGGAER_SELFSERVICEID",


### PR DESCRIPTION
Need to revert this until testing is completed in the CAS Development environment (otherwise this will block other changes that need to be rolled out)