### PR TITLE
Fix condition for creation of RDS Postgres tester

### DIFF
--- a/iac/compositions/cat-full/postgres_db.tf
+++ b/iac/compositions/cat-full/postgres_db.tf
@@ -24,7 +24,7 @@ module "db" {
 }
 
 module "create_rds_postgres_tester" {
-  count = var.environment_name != "production" ? 1 : 0
+  count = var.environment_name != "ci-production" && var.environment_name != "production" ? 1 : 0
   source = "../../core/modules/create-rds-postgres-tester"
 
   aws_account_id                         = var.aws_account_id


### PR DESCRIPTION
Ensures that the RDS Postgres Tester is not created in the production environment, which is actually called `ci-production` in the code. 