### PR TITLE
Implement IAC config to allow migration from Buyer UI to CAS UI

### DIFF
--- a/iac/compositions/cas-ui/variables.tf
+++ b/iac/compositions/cas-ui/variables.tf
@@ -8,6 +8,18 @@ variable "aws_region" {
   description = "Region into which to deploy region-specific resources"
 }
 
+variable "cas_ui_lb_listener_acm_arn" {
+  type        = string
+  description = "The full ARN of the ACM certificate to association with the CAS UI LB Listener (should be the redirect ACM cert)"
+  default     = "N/A"
+}
+
+variable "cas_ui_adopt_redirect_certificate" {
+  type        = bool
+  description = "Conditional to determine whether or not CAS UI should adopt the Redirect certificate (for the migration from Buyer UI to CAS UI - defaults to false)"
+  default     = false
+}
+
 variable "cas_ui_ingress_cidr_safelist" {
   type        = map(string)
   description = "Map of CIDR blocks from which to accept requests for the public-facing Load Balancer for the CAS UI, format {description: CIDR}"
@@ -27,6 +39,16 @@ variable "cas_ui_public_fqdn" {
   description = "FQDN corresponding to the HOST header which will be present on all UI requests - This will be CNAMEd to the domain specified in the `hosted_zone_ui` variable"
 }
 
+variable "cas_ui_lb_waf_enabled" {
+  type        = bool
+  description = "Boolean value specifying whether or not the CAS UI LB WAF Should be enabled"
+}
+
+variable "cas_web_acl_arn" {
+  type        = string
+  description = "The ARN of the Web ACL (to be associated with enabled Load Balancers)"
+}
+
 variable "cat_api_clients_security_group_id" {
   type        = string
   description = "CAT API clients security group ID"
@@ -37,6 +59,21 @@ variable "docker_image_tags" {
     cas_ui_http = string,
   })
   description = "Docker tag for deployment of each of the services from ECR"
+}
+
+variable "drop_invalid_header_fields" {
+  type        = bool
+  description = "Boolean to declare whether or not drop_invalid_header_fields should be enabled"
+}
+
+variable "lb_enable_deletion_protection" {
+  type        = bool
+  description = "Opt whether or not to enable deletion protection on Load Balancers"
+}
+
+variable "logs_bucket_id" {
+  type        = string
+  description = "The ID of the logs bucket (for logging on the Load Balancer)"
 }
 
 variable "ecr_repo_url" {

--- a/iac/compositions/cas-ui/waf_associations.tf
+++ b/iac/compositions/cas-ui/waf_associations.tf
@@ -1,0 +1,5 @@
+resource "aws_wafv2_web_acl_association" "cas_ui_web_acl_association" {
+  count        = var.cas_ui_lb_waf_enabled == true ? 1 : 0
+  resource_arn = aws_lb.cas_ui.arn
+  web_acl_arn  = var.cas_web_acl_arn
+}

--- a/iac/compositions/cat-full/logs_s3_bucket.tf
+++ b/iac/compositions/cat-full/logs_s3_bucket.tf
@@ -22,6 +22,34 @@ data "aws_iam_policy_document" "write_logs" {
     resources = [
       "arn:aws:s3:::${local.logs_bucket_name}/access-logs/buyerui/AWSLogs/${var.aws_account_id}/*",
       "arn:aws:s3:::${local.logs_bucket_name}/connection-logs/buyerui/AWSLogs/${var.aws_account_id}/*",
+      "arn:aws:s3:::${local.logs_bucket_name}/access-logs/casui/AWSLogs/${var.aws_account_id}/*",
+      "arn:aws:s3:::${local.logs_bucket_name}/connection-logs/casui/AWSLogs/${var.aws_account_id}/*",
+      "arn:aws:s3:::${local.logs_bucket_name}/access-logs/catapi/AWSLogs/${var.aws_account_id}/*",
+      "arn:aws:s3:::${local.logs_bucket_name}/connection-logs/catapi/AWSLogs/${var.aws_account_id}/*",
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "write_logs_without_cas_ui" {
+  version = "2012-10-17"
+
+  statement {
+    sid = "AllowAlbPutLogs"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${var.elb_account_id}:root"]
+    }
+
+    actions = [
+      "s3:PutObject"
+    ]
+
+    effect = "Allow"
+
+    resources = [
+      "arn:aws:s3:::${local.logs_bucket_name}/access-logs/buyerui/AWSLogs/${var.aws_account_id}/*",
+      "arn:aws:s3:::${local.logs_bucket_name}/connection-logs/buyerui/AWSLogs/${var.aws_account_id}/*",
       "arn:aws:s3:::${local.logs_bucket_name}/access-logs/catapi/AWSLogs/${var.aws_account_id}/*",
       "arn:aws:s3:::${local.logs_bucket_name}/connection-logs/catapi/AWSLogs/${var.aws_account_id}/*",
     ]
@@ -37,5 +65,5 @@ module "logs_bucket" {
 
 resource "aws_s3_bucket_policy" "logs_bucket_policy" {
   bucket = module.logs_bucket.bucket_id
-  policy = data.aws_iam_policy_document.write_logs.json
+  policy = var.logs_bucket_policy_include_cas_ui == true ? data.aws_iam_policy_document.write_logs.json : data.aws_iam_policy_document.write_logs_without_cas_ui.json
 }

--- a/iac/compositions/cat-full/manual_ssm_config.tf
+++ b/iac/compositions/cat-full/manual_ssm_config.tf
@@ -17,6 +17,7 @@ locals {
     "auth-server-client-id",
     "auth-server-client-secret",
     "auth-server-jwk-set-uri",
+    "cas-ui-load-balancer-name",
     "conclave-wrapper-api-base-url",
     "conclave-wrapper-api-key",
     "conclave-wrapper-identities-api-base-url",

--- a/iac/compositions/cat-full/outputs.tf
+++ b/iac/compositions/cat-full/outputs.tf
@@ -1,3 +1,8 @@
+output "buyer_ui_acm_certificate_arn" {
+  description = "ARN of the Buyer UI ACM certificate"
+  value       = aws_acm_certificate.public_buyer_ui.arn
+}
+
 output "cat_api_clients_security_group_id" {
   description = "CAT API clients security group ID"
   value       = aws_security_group.cat_api_clients.id
@@ -49,6 +54,11 @@ output "ingestion_bucket_id" {
 output "ingestion_bucket_write_objects_policy_document_json" {
   description = "JSON describing an IAM policy to allow writing of objects to the ingestion bucket"
   value       = module.ingestion_bucket.write_objects_policy_document_json
+}
+
+output "logs_bucket_id" {
+  description = "Full name of the logs bucket (for the Load Balancer)"
+  value       = module.logs_bucket.bucket_id
 }
 
 output "network_acl_ids" {

--- a/iac/compositions/cat-full/service_buyer_ui.tf
+++ b/iac/compositions/cat-full/service_buyer_ui.tf
@@ -23,7 +23,7 @@ resource "aws_lb" "buyer_ui" {
   }
 
   tags = {
-    WAF_ENABLED = var.cas_buyer_ui_lb_waf_enabled != false ? true : null
+    WAF_ENABLED = var.cas_buyer_ui_lb_waf_enabled == true ? true : null
   }
 }
 
@@ -34,7 +34,7 @@ resource "aws_route53_record" "buyer_ui" {
   zone_id         = var.hosted_zone_ui.id
 
   alias {
-    name                   = aws_lb.buyer_ui.dns_name
+    name                   = var.buyer_ui_redirect_r53_to_cas_ui == false ? aws_lb.buyer_ui.dns_name : aws_ssm_parameter.manual_config["cas-ui-load-balancer-name"].value
     zone_id                = aws_lb.buyer_ui.zone_id
     evaluate_target_health = true
   }

--- a/iac/compositions/cat-full/service_cat_api.tf
+++ b/iac/compositions/cat-full/service_cat_api.tf
@@ -51,7 +51,7 @@ resource "aws_lb" "cat_api" {
   }
 
   tags = {
-    WAF_ENABLED = var.cas_cat_api_lb_waf_enabled != false ? true : null
+    WAF_ENABLED = var.cas_cat_api_lb_waf_enabled == true ? true : null
   }
 }
 

--- a/iac/compositions/cat-full/variables.tf
+++ b/iac/compositions/cat-full/variables.tf
@@ -42,6 +42,12 @@ variable "buyer_ui_public_fqdn" {
   description = "FQDN corresponding to the HOST header which will be present on all UI requests - This will be CNAMEd to the domain specified in the `hosted_zone_ui` variable"
 }
 
+variable "buyer_ui_redirect_r53_to_cas_ui" {
+  type        = bool
+  description = "Conditional to determine whether or not the R53 record for the Buyer UI should be redirected to CAS UI (as part of the CAS UI migration - defaults to false)"
+  default     = false
+}
+
 variable "ca_cert_identifier" {
   type        = string
   description = "The identifier of the CA certificate for the DB instance."
@@ -177,6 +183,12 @@ variable "hosted_zone_ui" {
     name = string
   })
   description = "Properties of the Hosted Zone (which must be in the same AWS account as the resources) into which we will place alias and cert validation records for the UI"
+}
+
+variable "logs_bucket_policy_include_cas_ui" {
+  type        = bool
+  description = "Conditional to determine whether or not the logs bucket policy includes CAS UI"
+  default     = true
 }
 
 variable "rds_apply_immediately" {

--- a/iac/compositions/cat-full/waf_associations.tf
+++ b/iac/compositions/cat-full/waf_associations.tf
@@ -1,11 +1,11 @@
 resource "aws_wafv2_web_acl_association" "cas_buyer_ui_web_acl_association" {
-  count        = var.cas_buyer_ui_lb_waf_enabled != false ? 1 : 0
+  count        = var.cas_buyer_ui_lb_waf_enabled == true ? 1 : 0
   resource_arn = aws_lb.buyer_ui.arn
   web_acl_arn  = var.cas_web_acl_arn
 }
 
 resource "aws_wafv2_web_acl_association" "cas_cat_api_web_acl_association" {
-  count        = var.cas_cat_api_lb_waf_enabled != false ? 1 : 0
+  count        = var.cas_cat_api_lb_waf_enabled == true ? 1 : 0
   resource_arn = aws_lb.cat_api.arn
   web_acl_arn  = var.cas_web_acl_arn
 }

--- a/iac/environments/ci-development/cas_ui.tf
+++ b/iac/environments/ci-development/cas_ui.tf
@@ -3,12 +3,17 @@ module "cas_ui" {
 
   aws_account_id                          = var.aws_account_id
   aws_region                              = var.aws_region
+  cas_ui_adopt_redirect_certificate       = var.cas_ui_adopt_redirect_certificate
+  cas_ui_lb_listener_acm_arn              = module.cat_full.buyer_ui_acm_certificate_arn
   cas_ui_public_cert_attempt_validation   = var.cas_ui_public_cert_attempt_validation
   cas_ui_public_fqdn                      = var.cas_ui_public_fqdn
   cas_ui_ingress_cidr_safelist            = var.cas_ui_ingress_cidr_safelist
   cas_ui_replication_group_enabled        = var.replication_group_enabled
+  cas_web_acl_arn                         = data.aws_wafv2_web_acl.cas_web_acl.arn
+  cas_ui_lb_waf_enabled                   = var.cas_ui_lb_waf_enabled
   cat_api_clients_security_group_id       = module.cat_full.cat_api_clients_security_group_id
   docker_image_tags                       = var.docker_image_tags
+  drop_invalid_header_fields              = var.drop_invalid_header_fields
   ecr_repo_url                            = module.cat_full.ecr_repo_urls["cas-ui"]
   ecs_cluster_arn                         = module.cat_full.ecs_cluster_arn
   ecs_exec_policy_arn                     = module.cat_full.ecs_exec_policy_arn
@@ -19,6 +24,8 @@ module "cas_ui" {
   environment_is_ephemeral                = var.environment_is_ephemeral
   environment_name                        = var.environment_name
   hosted_zone_cas_ui                      = var.hosted_zone_cas_ui
+  lb_enable_deletion_protection           = var.lb_enable_deletion_protection
+  logs_bucket_id                          = module.cat_full.logs_bucket_id
   resource_name_prefixes                  = var.resource_name_prefixes
   task_container_configs                  = var.task_container_configs
   redis_credentials                       = module.cat_full.redis_credentials

--- a/iac/environments/ci-development/cat_full.tf
+++ b/iac/environments/ci-development/cat_full.tf
@@ -7,6 +7,7 @@ module "cat_full" {
   buyer_ui_ingress_cidr_safelist           = var.buyer_ui_ingress_cidr_safelist
   buyer_ui_public_cert_attempt_validation  = var.buyer_ui_public_cert_attempt_validation
   buyer_ui_public_fqdn                     = var.buyer_ui_public_fqdn
+  buyer_ui_redirect_r53_to_cas_ui          = var.buyer_ui_redirect_r53_to_cas_ui
   ca_cert_identifier                       = var.ca_cert_identifier
   cas_buyer_ui_lb_waf_enabled              = var.cas_buyer_ui_lb_waf_enabled
   cas_cat_api_lb_waf_enabled               = var.cas_cat_api_lb_waf_enabled

--- a/iac/environments/ci-development/variables.tf
+++ b/iac/environments/ci-development/variables.tf
@@ -33,6 +33,11 @@ variable "buyer_ui_public_fqdn" {
   description = "FQDN corresponding to the HOST header which will be present on all UI requests - This will be CNAMEd to the domain specified in the `hosted_zone_ui` variable"
 }
 
+variable "buyer_ui_redirect_r53_to_cas_ui" {
+  type        = bool
+  description = "Conditional to determine whether or not the R53 record for the Buyer UI should be redirected to CAS UI (as part of the CAS UI migration - defaults to false)"
+}
+
 variable "ca_cert_identifier" {
   type        = string
   description = "The identifier of the CA certificate for the DB instance."
@@ -46,6 +51,16 @@ variable "cas_buyer_ui_lb_waf_enabled" {
 variable "cas_cat_api_lb_waf_enabled" {
   type        = bool
   description = "Boolean value specifying whether or not the CAT API LB WAF Should be enabled"
+}
+
+variable "cas_ui_adopt_redirect_certificate" {
+  type        = bool
+  description = "Conditional to determine whether or not CAS UI should adopt the Redirect certificate (for the migration from Buyer UI to CAS UI - defaults to false)"
+}
+
+variable "cas_ui_lb_waf_enabled" {
+  type        = bool
+  description = "Boolean value specifying whether or not the CAS UI LB WAF Should be enabled"
 }
 
 variable "cas_web_acl_name" {

--- a/iac/environments/ci-nft/cas_ui.tf
+++ b/iac/environments/ci-nft/cas_ui.tf
@@ -3,12 +3,16 @@ module "cas_ui" {
 
   aws_account_id                          = var.aws_account_id
   aws_region                              = var.aws_region
+  cas_ui_lb_listener_acm_arn              = module.cat_full.buyer_ui_acm_certificate_arn
   cas_ui_public_cert_attempt_validation   = var.cas_ui_public_cert_attempt_validation
   cas_ui_public_fqdn                      = var.cas_ui_public_fqdn
   cas_ui_ingress_cidr_safelist            = var.cas_ui_ingress_cidr_safelist
   cas_ui_replication_group_enabled        = var.replication_group_enabled
   cat_api_clients_security_group_id       = module.cat_full.cat_api_clients_security_group_id
+  cas_web_acl_arn                         = var.cas_web_acl_arn
+  cas_ui_lb_waf_enabled                   = var.cas_ui_lb_waf_enabled
   docker_image_tags                       = var.docker_image_tags
+  drop_invalid_header_fields              = var.drop_invalid_header_fields
   ecr_repo_url                            = module.cat_full.ecr_repo_urls["cas-ui"]
   ecs_cluster_arn                         = module.cat_full.ecs_cluster_arn
   ecs_exec_policy_arn                     = module.cat_full.ecs_exec_policy_arn
@@ -19,6 +23,8 @@ module "cas_ui" {
   environment_is_ephemeral                = var.environment_is_ephemeral
   environment_name                        = var.environment_name
   hosted_zone_cas_ui                      = var.hosted_zone_cas_ui
+  lb_enable_deletion_protection           = var.lb_enable_deletion_protection
+  logs_bucket_id                          = module.cat_full.logs_bucket_id
   resource_name_prefixes                  = var.resource_name_prefixes
   task_container_configs                  = var.task_container_configs
   redis_credentials                       = module.cat_full.redis_credentials

--- a/iac/environments/ci-nft/variables.tf
+++ b/iac/environments/ci-nft/variables.tf
@@ -48,6 +48,11 @@ variable "cas_cat_api_lb_waf_enabled" {
   description = "Boolean value specifying whether or not the CAT API LB WAF Should be enabled"
 }
 
+variable "cas_ui_lb_waf_enabled" {
+  type        = bool
+  description = "Boolean value specifying whether or not the CAS UI LB WAF Should be enabled"
+}
+
 variable "cas_web_acl_arn" {
   type        = string
   description = "The ARN of the Web ACL (to be associated with enabled Load Balancers)"

--- a/iac/environments/ci-pre/cas_ui.tf
+++ b/iac/environments/ci-pre/cas_ui.tf
@@ -3,12 +3,16 @@ module "cas_ui" {
 
   aws_account_id                          = var.aws_account_id
   aws_region                              = var.aws_region
+  cas_ui_adopt_redirect_certificate       = var.cas_ui_adopt_redirect_certificate
   cas_ui_public_cert_attempt_validation   = var.cas_ui_public_cert_attempt_validation
   cas_ui_public_fqdn                      = var.cas_ui_public_fqdn
   cas_ui_ingress_cidr_safelist            = var.cas_ui_ingress_cidr_safelist
   cas_ui_replication_group_enabled        = var.replication_group_enabled
   cat_api_clients_security_group_id       = module.cat_full.cat_api_clients_security_group_id
+  cas_web_acl_arn                         = data.aws_wafv2_web_acl.cas_web_acl.arn
+  cas_ui_lb_waf_enabled                   = var.cas_ui_lb_waf_enabled
   docker_image_tags                       = var.docker_image_tags
+  drop_invalid_header_fields              = var.drop_invalid_header_fields
   ecr_repo_url                            = module.cat_full.ecr_repo_urls["cas-ui"]
   ecs_cluster_arn                         = module.cat_full.ecs_cluster_arn
   ecs_exec_policy_arn                     = module.cat_full.ecs_exec_policy_arn
@@ -19,6 +23,8 @@ module "cas_ui" {
   environment_is_ephemeral                = var.environment_is_ephemeral
   environment_name                        = var.environment_name
   hosted_zone_cas_ui                      = var.hosted_zone_cas_ui
+  lb_enable_deletion_protection           = var.lb_enable_deletion_protection
+  logs_bucket_id                          = module.cat_full.logs_bucket_id
   resource_name_prefixes                  = var.resource_name_prefixes
   task_container_configs                  = var.task_container_configs
   redis_credentials                       = module.cat_full.redis_credentials

--- a/iac/environments/ci-pre/cat_full.tf
+++ b/iac/environments/ci-pre/cat_full.tf
@@ -8,6 +8,7 @@ module "cat_full" {
   buyer_ui_idle_timeout                    = var.buyer_ui_idle_timeout
   buyer_ui_public_cert_attempt_validation  = var.buyer_ui_public_cert_attempt_validation
   buyer_ui_public_fqdn                     = var.buyer_ui_public_fqdn
+  buyer_ui_redirect_r53_to_cas_ui          = var.buyer_ui_redirect_r53_to_cas_ui
   ca_cert_identifier                       = var.ca_cert_identifier
   cas_buyer_ui_lb_waf_enabled              = var.cas_buyer_ui_lb_waf_enabled
   cas_cat_api_lb_waf_enabled               = var.cas_cat_api_lb_waf_enabled

--- a/iac/environments/ci-pre/variables.tf
+++ b/iac/environments/ci-pre/variables.tf
@@ -37,6 +37,11 @@ variable "buyer_ui_public_fqdn" {
   description = "FQDN corresponding to the HOST header which will be present on all UI requests - This will be CNAMEd to the domain specified in the `hosted_zone_ui` variable"
 }
 
+variable "buyer_ui_redirect_r53_to_cas_ui" {
+  type        = bool
+  description = "Conditional to determine whether or not the R53 record for the Buyer UI should be redirected to CAS UI (as part of the CAS UI migration - defaults to false)"
+}
+
 variable "ca_cert_identifier" {
   type        = string
   description = "The identifier of the CA certificate for the DB instance."
@@ -52,9 +57,19 @@ variable "cas_cat_api_lb_waf_enabled" {
   description = "Boolean value specifying whether or not the CAT API LB WAF Should be enabled"
 }
 
+variable "cas_ui_lb_waf_enabled" {
+  type        = bool
+  description = "Boolean value specifying whether or not the CAS UI LB WAF Should be enabled"
+}
+
 variable "cas_web_acl_name" {
   type        = string
   description = "The name of the Web ACL (to be associated with enabled Load Balancers)"
+}
+
+variable "cas_ui_adopt_redirect_certificate" {
+  type        = bool
+  description = "Conditional to determine whether or not CAS UI should adopt the Redirect certificate (for the migration from Buyer UI to CAS UI - defaults to false)"
 }
 
 variable "cas_ui_ingress_cidr_safelist" {

--- a/iac/environments/ci-production/cat_full.tf
+++ b/iac/environments/ci-production/cat_full.tf
@@ -31,6 +31,7 @@ module "cat_full" {
   hosted_zone_api                          = var.hosted_zone_api
   hosted_zone_ui                           = var.hosted_zone_ui
   lb_enable_deletion_protection            = var.lb_enable_deletion_protection
+  logs_bucket_policy_include_cas_ui        = false
   rds_allocated_storage_gb                 = var.rds_allocated_storage_gb
   rds_backup_retention_period_days         = var.rds_backup_retention_period_days
   rds_backup_window                        = var.rds_backup_window

--- a/iac/environments/ci-uat/cas_ui.tf
+++ b/iac/environments/ci-uat/cas_ui.tf
@@ -3,12 +3,17 @@ module "cas_ui" {
 
   aws_account_id                          = var.aws_account_id
   aws_region                              = var.aws_region
+  cas_ui_adopt_redirect_certificate       = var.cas_ui_adopt_redirect_certificate
+  cas_ui_lb_listener_acm_arn              = module.cat_full.buyer_ui_acm_certificate_arn
   cas_ui_public_cert_attempt_validation   = var.cas_ui_public_cert_attempt_validation
   cas_ui_public_fqdn                      = var.cas_ui_public_fqdn
   cas_ui_ingress_cidr_safelist            = var.cas_ui_ingress_cidr_safelist
   cas_ui_replication_group_enabled        = var.replication_group_enabled
   cat_api_clients_security_group_id       = module.cat_full.cat_api_clients_security_group_id
+  cas_web_acl_arn                         = data.aws_wafv2_web_acl.cas_web_acl.arn
+  cas_ui_lb_waf_enabled                   = var.cas_ui_lb_waf_enabled
   docker_image_tags                       = var.docker_image_tags
+  drop_invalid_header_fields              = var.drop_invalid_header_fields
   ecr_repo_url                            = module.cat_full.ecr_repo_urls["cas-ui"]
   ecs_cluster_arn                         = module.cat_full.ecs_cluster_arn
   ecs_exec_policy_arn                     = module.cat_full.ecs_exec_policy_arn
@@ -19,6 +24,8 @@ module "cas_ui" {
   environment_is_ephemeral                = var.environment_is_ephemeral
   environment_name                        = var.environment_name
   hosted_zone_cas_ui                      = var.hosted_zone_cas_ui
+  lb_enable_deletion_protection           = var.lb_enable_deletion_protection
+  logs_bucket_id                          = module.cat_full.logs_bucket_id
   resource_name_prefixes                  = var.resource_name_prefixes
   task_container_configs                  = var.task_container_configs
   redis_credentials                       = module.cat_full.redis_credentials

--- a/iac/environments/ci-uat/cat_full.tf
+++ b/iac/environments/ci-uat/cat_full.tf
@@ -7,6 +7,7 @@ module "cat_full" {
   buyer_ui_ingress_cidr_safelist           = var.buyer_ui_ingress_cidr_safelist
   buyer_ui_public_cert_attempt_validation  = var.buyer_ui_public_cert_attempt_validation
   buyer_ui_public_fqdn                     = var.buyer_ui_public_fqdn
+  buyer_ui_redirect_r53_to_cas_ui          = var.buyer_ui_redirect_r53_to_cas_ui
   ca_cert_identifier                       = var.ca_cert_identifier
   cas_buyer_ui_lb_waf_enabled              = var.cas_buyer_ui_lb_waf_enabled
   cas_cat_api_lb_waf_enabled               = var.cas_cat_api_lb_waf_enabled

--- a/iac/environments/ci-uat/variables.tf
+++ b/iac/environments/ci-uat/variables.tf
@@ -33,6 +33,11 @@ variable "buyer_ui_public_fqdn" {
   description = "FQDN corresponding to the HOST header which will be present on all UI requests - This will be CNAMEd to the domain specified in the `hosted_zone_ui` variable"
 }
 
+variable "buyer_ui_redirect_r53_to_cas_ui" {
+  type        = bool
+  description = "Conditional to determine whether or not the R53 record for the Buyer UI should be redirected to CAS UI (as part of the CAS UI migration - defaults to false)"
+}
+
 variable "ca_cert_identifier" {
   type        = string
   description = "The identifier of the CA certificate for the DB instance."
@@ -48,9 +53,19 @@ variable "cas_cat_api_lb_waf_enabled" {
   description = "Boolean value specifying whether or not the CAT API LB WAF Should be enabled"
 }
 
+variable "cas_ui_lb_waf_enabled" {
+  type        = bool
+  description = "Boolean value specifying whether or not the CAS UI LB WAF Should be enabled"
+}
+
 variable "cas_web_acl_name" {
   type        = string
   description = "The name of the Web ACL (to be associated with enabled Load Balancers)"
+}
+
+variable "cas_ui_adopt_redirect_certificate" {
+  type        = bool
+  description = "Conditional to determine whether or not CAS UI should adopt the Redirect certificate (for the migration from Buyer UI to CAS UI - defaults to false)"
 }
 
 variable "cas_ui_ingress_cidr_safelist" {


### PR DESCRIPTION
This PR implements the following:
- Introduces the ability to enable a WAF + update ELB configurations for security enhancements + enable access logging (as per GMTRP-336) for the CAS UI Load Balancer
- Introduces the capability to update DNS records + TLS Certs/Listener Certificates in order to update the existing redirect.contractawardservice records to point to CAS UI rather than Buyer UI (via boolean variables, where true = switch to CAS UI, while false = continue pointing to Buyer UI)
- Create a cas-ui-load-balancer-name which stores the CAS UI Load Balancer name, if the intention is to switch over to CAS UI (this is a temporary workaround until the migration is complete and we can do some additional refactoring, as we cannot have the CAS_UI compositions depending on outputs from the CAT_FULL composition while the opposite is also still in effect)
- Update the non-production environment configurations as appropriate (currently we're enabling this for Devleopment and UAT, but not Pre-Production)